### PR TITLE
BUG FIX - Added VARCHAR length for region

### DIFF
--- a/pipeline/database/schema.sql
+++ b/pipeline/database/schema.sql
@@ -19,7 +19,7 @@ GO
 
 CREATE TABLE s_delta.location (
     location_id INT NOT NULL IDENTITY(1, 1) PRIMARY KEY,
-    region VARCHAR,
+    region VARCHAR(100),
     country VARCHAR(50),
     continent VARCHAR(20)
 );


### PR DESCRIPTION
In order to fix a bug related to inserting data into the region column for the location table, I've added a specific maximum length for the VARCHAR data type (100).