### PR TITLE
BUG FIX: Changed plant_id 

### DIFF
--- a/pipeline/database/schema.sql
+++ b/pipeline/database/schema.sql
@@ -34,7 +34,7 @@ CREATE TABLE s_delta.botanist(
 GO
 
 CREATE TABLE s_delta.plant(
-    plant_id INT NOT NULL IDENTITY(1, 1) PRIMARY KEY,
+    plant_id INT NOT NULL PRIMARY KEY,
     name VARCHAR(100),
     location_id INT,
     botanist_id INT,


### PR DESCRIPTION
Removed the IDENTITY(1, 1) property from the plant_id column in the plant table, to fix a bug where the plant IDs weren't matching up correctly.