### PR TITLE
Added the terraform to create a schedule and task definition to load old data.

### DIFF
--- a/pipeline/extract.py
+++ b/pipeline/extract.py
@@ -58,7 +58,7 @@ def fetch_plant_data(current_plant):
     Fetches data for a single plant.
     """
     try:
-        response = requests.get(f"{API_URL}{current_plant}", timeout=10)
+        response = requests.get(f"{API_URL}{current_plant}", timeout=20)
         plant_json = response.json()
         plant_keys = plant_json.keys()
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,3 +62,37 @@ network_configuration {
     assign_public_ip = true
   }
 }
+
+
+
+resource "aws_ecs_task_definition" "c9-ladybirds-load-old-data-task" {
+  family                   = "c9-ladybirds-load-old-data-task"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 1024
+  memory                   = 2048
+  execution_role_arn       = "${data.aws_iam_role.ecs_task_execution_role.arn}"
+  container_definitions    = <<TASK_DEFINITION
+[
+  {
+    "environment": [
+      {"name": "DB_HOST", "value": "${var.database_ip}"},
+      {"name": "DB_NAME", "value": "${var.database_name}"},
+      {"name": "DB_PASSWORD", "value": "${var.database_password}"},
+      {"name": "DB_PORT", "value": "${var.database_port}"},
+      {"name": "DB_USERNAME", "value": "${var.database_username}"},
+      {"name": "AWS_ACCESS_KEY_ID", "value": "${var.aws_access_key_id}"},
+      {"name": "AWS_SECRET_ACCESS_KEY", "value": "${var.aws_secret_access_key}"}
+    ],
+    "name": "c9-ladybirds-load-old-data",
+    "image": "129033205317.dkr.ecr.eu-west-2.amazonaws.com/c9-ladybirds-load-old-data:latest",
+    "essential": true
+  }
+]
+TASK_DEFINITION
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -178,7 +178,7 @@ resource "aws_scheduler_schedule" "c9-ladybirds-load-old-data" {
     mode = "FLEXIBLE"
   }
   schedule_expression_timezone = "Europe/London"
-  schedule_expression = "cron(09 15 * * ? *)" 
+  schedule_expression = "cron(05 09 * * ? *)" 
 
   target {
     arn      = "arn:aws:ecs:eu-west-2:129033205317:cluster/c9-ecs-cluster" # arn of the ecs cluster to run on

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,3 +25,15 @@ variable "database_name" {
   type        = string
   default = "value"
 }
+
+variable "aws_access_key_id" {
+  description = "Value of the aws access key id"
+  type        = string
+  default = "value"
+}
+
+variable "aws_secret_access_key" {
+  description = "Value of the aws secret access key"
+  type        = string
+  default = "value"
+}


### PR DESCRIPTION
Created the terraform code so when applied a new task definition gets created for the load-old-data repo.
Code for a event bridge schedule has also been created that will run every day at 9:05 and delete data from the database and reupload it to the S3 long term storage.

**
Increased the timeout for the api as its became slower.